### PR TITLE
Fixed CSS Class labels

### DIFF
--- a/classy_paragraphs_ui.module
+++ b/classy_paragraphs_ui.module
@@ -215,6 +215,6 @@ function classy_paragraphs_ui_classy_paragraphs_list_options_alter(&$options) {
   $setting_array =variable_get('classy_paragraphs_settings');
 
   foreach ($setting_array as $key => $value){
-    $options[$value['css_class_name']] = t($value['css_class_name']);
+    $options[$value['css_class_name']] = t($value['css_class_display']);
   }
 }


### PR DESCRIPTION
Fixes issue where end user was seeing classes that were being applied instead of the label

Before:
![screenshot 2015-05-29 10 13 59](https://cloud.githubusercontent.com/assets/3298524/7885768/70e1d398-05eb-11e5-8a10-7e10712ef7ff.png)

After:
![screenshot 2015-05-29 10 12 08](https://cloud.githubusercontent.com/assets/3298524/7885730/3387250c-05eb-11e5-80ee-60acbf44c382.png)
